### PR TITLE
Add README, fix doc comments, drop redundant loop-var shadowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,221 @@
+# await
+
+[![Test](https://github.com/snicol/await/actions/workflows/test.yml/badge.svg)](https://github.com/snicol/await/actions/workflows/test.yml)
+[![Lint](https://github.com/snicol/await/actions/workflows/lint.yml/badge.svg)](https://github.com/snicol/await/actions/workflows/lint.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/snicol/await.svg)](https://pkg.go.dev/github.com/snicol/await)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+`await` is a tiny, generic Go library for running work concurrently over a
+single value, a slice, or a map. It is a thin, type-safe layer on top of
+[`golang.org/x/sync/errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup)
+that removes the boilerplate of spawning goroutines, wiring up a shared context,
+and collecting results — while keeping the same fail-fast error semantics you
+already expect from `errgroup`.
+
+## Features
+
+- **Generics-first.** Works over `[]T`, `map[K]V`, or any single `T` with no
+  `interface{}` and no type assertions.
+- **Fail-fast.** The first non-nil error cancels the shared context and is
+  returned from `Wait`, just like `errgroup`.
+- **Panic-safe.** A panic in a worker goroutine is recovered and returned as a
+  `PanicError` instead of crashing your process.
+- **Result collection without the bookkeeping.** Replace values in place
+  (`SliceReplace` / `MapReplace`) or collect new results (`SliceReturn` /
+  `MapReturn`) without writing your own mutexes or index juggling.
+- **Concurrency limiting.** Cap the number of in-flight goroutines with
+  `WithLimit`.
+- **Two ergonomics.** Build a `Group` and chain several calls onto it, or use
+  the one-shot `*Context` helpers for single calls.
+
+## Installation
+
+```sh
+go get github.com/snicol/await
+```
+
+Requires Go 1.25 or newer (per [go.mod](go.mod)).
+
+```go
+import "github.com/snicol/await"
+```
+
+## Quick start
+
+```go
+ctx := context.Background()
+
+ids := []string{"id_a", "id_b", "id_c"}
+
+// Run fn over every item, concurrently. Returns the first error (or nil).
+err := await.SliceContext(ctx, ids, func(ctx context.Context, id string) error {
+    return process(ctx, id)
+})
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+## Concepts
+
+### Groups vs. `*Context` helpers
+
+There are two ways to use the library:
+
+1. **Build a `Group` and register work on it.** This lets you fan out several
+   different operations onto a single group and wait for all of them together.
+
+   ```go
+   g := await.Group(ctx, await.WithLimit(10)) // optional concurrency cap
+
+   await.Slice(g, ids, fetchOne)              // fan out over a slice
+   await.Any(g, &report, buildReport)         // plus a single one-off call
+
+   if err := g.Wait(); err != nil {           // run everything, wait, return
+       return err
+   }
+   ```
+
+2. **Use the one-shot `*Context` helpers.** These construct a group, register
+   the work, and call `Wait` for you. You lose the ability to chain multiple
+   calls onto one group, but they read better for single operations.
+
+   ```go
+   err := await.SliceContext(ctx, ids, fetchOne)
+   ```
+
+Nothing runs until `Wait` is called (directly, or by a `*Context` helper).
+`Wait` blocks until every registered function has returned, then returns the
+first error encountered — or nil if all succeeded.
+
+### Error handling and cancellation
+
+All work registered on a group shares a single context derived from the one you
+pass to `Group`. The moment any function returns a non-nil error, that context
+is cancelled, signalling the other in-flight functions to stop early (provided
+they respect `ctx.Done()`). `Wait` returns that first error.
+
+### Panic recovery
+
+If a worker function panics, `await` recovers the panic and returns it from
+`Wait` as a `PanicError`, rather than letting it unwind and crash the process:
+
+```go
+err := await.SliceContext(ctx, ids, mightPanic)
+
+var pe await.PanicError
+if errors.As(err, &pe) {
+    log.Printf("a worker panicked: %v", pe.Panic)
+}
+```
+
+## API overview
+
+### Constructing a group
+
+| Function | Description |
+|----------|-------------|
+| `Group(ctx, ...Option) ctxErrgroup` | Create a group bound to `ctx`. |
+| `WithLimit(n) Option` | Cap concurrent goroutines at `n` (non-positive = unlimited). |
+
+### Registering work on a group
+
+| Function | Input | Behaviour |
+|----------|-------|-----------|
+| `Any(g, v, fn)` | a single `T` | Run `fn(ctx, v)` once. |
+| `Slice(g, vs, fn)` | `[]T` | Run `fn(ctx, v)` for each element. |
+| `Map(g, vs, fn)` | `map[K]V` | Run `fn(ctx, k, v)` for each pair. |
+| `SliceReplace(g, vs, fn)` | `[]T` | Replace each element in place with `fn`'s result. |
+| `MapReplace(g, vs, fn)` | `map[K]V` | Replace each value in place with `fn`'s result. |
+| `SliceReturn(g, vs, fn) []O` | `[]T` | Collect `fn`'s results into a new, order-preserving slice. |
+| `MapReturn(g, vs, fn) map[K]VO` | `map[K]V` | Collect `fn`'s (key, value) results into a new map. |
+
+For `*Return` helpers, do not read the returned slice/map until `Wait` has
+returned. Ordering of `SliceReturn` matches the input: result `i` corresponds to
+input `i`.
+
+### One-shot `*Context` helpers
+
+Each constructs a group, registers the work, and calls `Wait` for you:
+
+| Function | Equivalent to |
+|----------|---------------|
+| `SliceContext(ctx, vs, fn) error` | `Group` + `Slice` + `Wait` |
+| `MapContext(ctx, vs, fn) error` | `Group` + `Map` + `Wait` |
+| `SliceReplaceContext(ctx, vs, fn) error` | `Group` + `SliceReplace` + `Wait` |
+| `SliceReturnContext(ctx, vs, fn) ([]O, error)` | `Group` + `SliceReturn` + `Wait` |
+
+## Examples
+
+### Collecting results from a slice
+
+```go
+ids := []string{"id_a", "id_b", "id_c"}
+
+responses, err := await.SliceReturnContext(ctx, ids,
+    func(ctx context.Context, id string) (Response, error) {
+        return client.Get(ctx, id)
+    },
+)
+if err != nil {
+    return err
+}
+// responses[i] corresponds to ids[i].
+```
+
+### Replacing slice values in place
+
+```go
+// Concurrently transform every element, mutating the slice in place.
+err := await.SliceReplaceContext(ctx, ids,
+    func(ctx context.Context, id string) (string, error) {
+        return normalize(ctx, id)
+    },
+)
+```
+
+### Transforming a map
+
+```go
+g := await.Group(ctx)
+
+// fn returns a (possibly new) key, a value, and an error.
+out := await.MapReturn(g, in,
+    func(ctx context.Context, k string, v int) (string, string, error) {
+        return strings.ToUpper(k), strconv.Itoa(v), nil
+    },
+)
+
+if err := g.Wait(); err != nil {
+    return err
+}
+// out is safe to read now.
+```
+
+A fuller, runnable example lives in [await_test.go](await_test.go).
+
+## Thread safety notes
+
+- `Slice`, `SliceReplace`, and `SliceReturn` each have every goroutine write to
+  a distinct slice index, so no locking is required.
+- `MapReplace` and `MapReturn` guard their map writes with a mutex, because Go
+  maps are not safe for concurrent writes.
+- `Any` and `Slice` make **no** guarantees about safe concurrent access to your
+  values. If your `fn` mutates shared state, you are responsible for
+  synchronizing it. Use the `*Replace` / `*Return` helpers when you need results
+  written back safely.
+
+## Development
+
+```sh
+go test ./...     # run tests
+go vet ./...      # vet
+golangci-lint run # lint (config in .golangci.yml)
+```
+
+CI runs tests and linting on every push via the workflows in
+[.github/workflows](.github/workflows).
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/await.go
+++ b/await.go
@@ -18,7 +18,7 @@ func Any[T any](g ctxErrgroup, v T, fn func(context.Context, T) error) {
 
 // Slice takes a slice of any input, and asynchronously calls `fn` once for
 // every item, each in its own goroutine on the group. If any error is
-// encountered, the group's context is cancelled and execution stops.
+// encountered, the group's context is canceled and execution stops.
 func Slice[T any](g ctxErrgroup, vs []T, fn func(context.Context, T) error) {
 	for _, v := range vs {
 		Any(g, v, fn)
@@ -27,7 +27,7 @@ func Slice[T any](g ctxErrgroup, vs []T, fn func(context.Context, T) error) {
 
 // Map takes a map of any input, and asynchronously calls `fn` once for each
 // K/V pair, each in its own goroutine on the group. If any error is
-// encountered, the group's context is cancelled and execution stops.
+// encountered, the group's context is canceled and execution stops.
 func Map[K comparable, V any](g ctxErrgroup, vs map[K]V, fn func(context.Context, K, V) error) {
 	for k, v := range vs {
 		g.Go(func(ctx context.Context) error {

--- a/await.go
+++ b/await.go
@@ -4,33 +4,32 @@ import (
 	"context"
 )
 
-// Any takes any input, and asyncronously calls `fn`.
-// If any error is encoutered, the context is canceled and execution stops.
-// n.b. this method does not provide any thread-safe guarantees on T.
+// Any takes any input, and asynchronously calls `fn` with it on the group.
+// If any error is encountered, the group's context is canceled and execution
+// stops for every other call registered on the group.
+// n.b. this method does not provide any thread-safe guarantees on T; if fn
+// mutates T concurrently with other goroutines you must synchronize access
+// yourself (see SliceReplace/MapReplace for safe mutation helpers).
 func Any[T any](g ctxErrgroup, v T, fn func(context.Context, T) error) {
 	g.Go(func(ctx context.Context) error {
 		return fn(ctx, v)
 	})
 }
 
-// Slice takes a slice of any input, and asyncronously calls `fn` over
-// every item. If any error is encoutered, the context is cancelled and
-// execution stops.
+// Slice takes a slice of any input, and asynchronously calls `fn` once for
+// every item, each in its own goroutine on the group. If any error is
+// encountered, the group's context is cancelled and execution stops.
 func Slice[T any](g ctxErrgroup, vs []T, fn func(context.Context, T) error) {
 	for _, v := range vs {
-		v := v
-
 		Any(g, v, fn)
 	}
 }
 
-// Map takes a map of any input, and asyncronously calls `fn` over each K/V
-// pair. If any error is encoutered, the context is cancelled and execution
-// stops.
+// Map takes a map of any input, and asynchronously calls `fn` once for each
+// K/V pair, each in its own goroutine on the group. If any error is
+// encountered, the group's context is cancelled and execution stops.
 func Map[K comparable, V any](g ctxErrgroup, vs map[K]V, fn func(context.Context, K, V) error) {
 	for k, v := range vs {
-		k, v := k, v
-
 		g.Go(func(ctx context.Context) error {
 			return fn(ctx, k, v)
 		})

--- a/await_context.go
+++ b/await_context.go
@@ -3,8 +3,9 @@ package await
 import "context"
 
 // SliceContext is a convenience method which calls Slice, but constructs the
-// Group for you. This is useful if you do not require chaining the group with
-// any other types.
+// Group and Waits on it for you. This is useful if you do not require chaining
+// other calls onto the same group: it runs fn over every item and returns the
+// first error (or nil).
 func SliceContext[T any](ctx context.Context, vs []T, fn func(context.Context, T) error) error {
 	g := Group(ctx)
 
@@ -13,9 +14,10 @@ func SliceContext[T any](ctx context.Context, vs []T, fn func(context.Context, T
 	return g.Wait()
 }
 
-// SliceReplaceContext is a convenience method which calls SliceReplace,
-// but constructs the Group for you. This is useful if you do not require
-// chaining the group with any other types.
+// SliceReplaceContext is a convenience method which calls SliceReplace, but
+// constructs the Group and Waits on it for you. This is useful if you do not
+// require chaining other calls onto the same group. The input slice is mutated
+// in place once Wait returns without error.
 func SliceReplaceContext[T any](ctx context.Context, vs []T, fn func(context.Context, T) (T, error)) error {
 	g := Group(ctx)
 
@@ -24,9 +26,10 @@ func SliceReplaceContext[T any](ctx context.Context, vs []T, fn func(context.Con
 	return g.Wait()
 }
 
-// SliceReplaceContext is a convenience method which calls SliceReplace,
-// but constructs the Group for you. This is useful if you do not require
-// chaining the group with any other types.
+// SliceReturnContext is a convenience method which calls SliceReturn, but
+// constructs the Group and Waits on it for you. It returns the collected
+// results (in input order) or the first error encountered. This is useful if
+// you do not require chaining other calls onto the same group.
 func SliceReturnContext[T, O any](ctx context.Context, vs []T, fn func(context.Context, T) (O, error)) ([]O, error) {
 	g := Group(ctx)
 
@@ -39,9 +42,10 @@ func SliceReturnContext[T, O any](ctx context.Context, vs []T, fn func(context.C
 	return o, nil
 }
 
-// MapContext is a convenience method which calls Map, but constructs the
-// Group for you. This is useful if you do not require chaining the group with
-// any other types.
+// MapContext is a convenience method which calls Map, but constructs the Group
+// and Waits on it for you. It runs fn over every K/V pair and returns the first
+// error (or nil). This is useful if you do not require chaining other calls
+// onto the same group.
 func MapContext[K comparable, V any](ctx context.Context, vs map[K]V, fn func(context.Context, K, V) error) error {
 	g := Group(ctx)
 

--- a/await_replace.go
+++ b/await_replace.go
@@ -5,45 +5,48 @@ import (
 	"sync"
 )
 
-// SliceReplace takes a slice of any input, and asyncronously calls `fn` over
+// SliceReplace takes a slice of any input, and asynchronously calls `fn` over
 // every item, replacing the value in the slice with the one returned by `fn`.
-// If any error is encoutered, the context is cancelled and execution stops.
+// If any error is encountered, the group's context is cancelled and execution
+// stops.
 // This function is useful if you wish to modify the values of the slice as a
-// result of an asynchronous call, without changing the underlying pointer
-// value which could result in data races.
+// result of an asynchronous call. Each goroutine writes to a distinct index, so
+// no locking is required and the original slice is mutated in place.
+// The slice should not be read until the group's Wait has returned.
 func SliceReplace[T any](g ctxErrgroup, vs []T, fn func(context.Context, T) (T, error)) {
 	for i, v := range vs {
-		i, v := i, v
-
 		g.Go(func(ctx context.Context) error {
 			res, err := fn(ctx, v)
 			if err != nil {
 				return err
 			}
 
+			// Safe without a lock: every goroutine owns a unique index i.
 			vs[i] = res
 			return nil
 		})
 	}
 }
 
-// MapReplace takes a map of any input, and asyncronously calls `fn` over
+// MapReplace takes a map of any input, and asynchronously calls `fn` over
 // every item, replacing the value in the map with the one returned by `fn`.
-// If any error is encoutered, the context is cancelled and execution stops.
+// If any error is encountered, the group's context is cancelled and execution
+// stops.
 // This function is useful if you wish to modify the values of the map as a
-// result of an asynchronous call, as all operations are wrapped in a mutex for
-// safety.
+// result of an asynchronous call. Writes back to the map are guarded by a mutex
+// because Go maps are not safe for concurrent writes.
+// The map should not be read until the group's Wait has returned.
 func MapReplace[K comparable, V any](g ctxErrgroup, vs map[K]V, fn func(context.Context, K, V) (V, error)) {
 	m := &sync.Mutex{}
 
 	for k, v := range vs {
-		k, v := k, v
-
 		g.Go(func(ctx context.Context) error {
 			res, err := fn(ctx, k, v)
 			if err != nil {
 				return err
 			}
+
+			// Guard the map write: concurrent writes to a Go map panic.
 			defer m.Unlock()
 			m.Lock()
 

--- a/await_replace.go
+++ b/await_replace.go
@@ -7,7 +7,7 @@ import (
 
 // SliceReplace takes a slice of any input, and asynchronously calls `fn` over
 // every item, replacing the value in the slice with the one returned by `fn`.
-// If any error is encountered, the group's context is cancelled and execution
+// If any error is encountered, the group's context is canceled and execution
 // stops.
 // This function is useful if you wish to modify the values of the slice as a
 // result of an asynchronous call. Each goroutine writes to a distinct index, so
@@ -30,7 +30,7 @@ func SliceReplace[T any](g ctxErrgroup, vs []T, fn func(context.Context, T) (T, 
 
 // MapReplace takes a map of any input, and asynchronously calls `fn` over
 // every item, replacing the value in the map with the one returned by `fn`.
-// If any error is encountered, the group's context is cancelled and execution
+// If any error is encountered, the group's context is canceled and execution
 // stops.
 // This function is useful if you wish to modify the values of the map as a
 // result of an asynchronous call. Writes back to the map are guarded by a mutex

--- a/await_return.go
+++ b/await_return.go
@@ -5,24 +5,25 @@ import (
 	"sync"
 )
 
-// SliceReturn takes a slice of any input, and asyncronously calls `fn` over
-// every item, collecting the return values of each execution to be returned as
-// a new slice when finished.
-// If any error is encoutered, the context is cancelled and execution stops.
-// The returned slice should not be accessed until the the group's Wait has
-// finished.
+// SliceReturn takes a slice of any input, and asynchronously calls `fn` over
+// every item, collecting the return values of each execution into a new slice.
+// The returned slice has the same length and ordering as the input: result i
+// corresponds to input i.
+// If any error is encountered, the group's context is cancelled and execution
+// stops.
+// The returned slice should not be accessed until the group's Wait has
+// returned.
 func SliceReturn[T, O any](g ctxErrgroup, vs []T, fn func(context.Context, T) (O, error)) []O {
 	out := make([]O, len(vs))
 
 	for i, v := range vs {
-		i, v := i, v
-
 		g.Go(func(ctx context.Context) error {
 			res, err := fn(ctx, v)
 			if err != nil {
 				return err
 			}
 
+			// Safe without a lock: every goroutine owns a unique index i.
 			out[i] = res
 			return nil
 		})
@@ -31,26 +32,28 @@ func SliceReturn[T, O any](g ctxErrgroup, vs []T, fn func(context.Context, T) (O
 	return out
 }
 
-// MapReturn takes a map of any input, and asyncronously calls `fn` over
-// every item, returning a key, value pair or error. If
-// If any error is encoutered, the context is cancelled and execution stops.
-// This function is useful if you wish to modify the values of the slice as a
-// result of an asynchronous call, without changing the underlying pointer
-// value which could result in data races.
-// The returned map should not be accessed until the the group's Wait has
-// finished.
+// MapReturn takes a map of any input, and asynchronously calls `fn` over every
+// item. `fn` returns a (possibly new) key, a value, and an error; the returned
+// key/value pair is collected into a new output map. This lets you transform
+// both the keys and the values of a map concurrently.
+// If any error is encountered, the group's context is cancelled and execution
+// stops.
+// Writes back to the output map are guarded by a mutex because Go maps are not
+// safe for concurrent writes. If `fn` returns the same key for two different
+// inputs, the last write wins.
+// The returned map should not be accessed until the group's Wait has returned.
 func MapReturn[K comparable, V, VO any](g ctxErrgroup, vs map[K]V, fn func(context.Context, K, V) (K, VO, error)) map[K]VO {
 	m := &sync.Mutex{}
 	out := make(map[K]VO, len(vs))
 
 	for k, v := range vs {
-		k, v := k, v
-
 		g.Go(func(ctx context.Context) error {
 			newKey, res, err := fn(ctx, k, v)
 			if err != nil {
 				return err
 			}
+
+			// Guard the map write: concurrent writes to a Go map panic.
 			defer m.Unlock()
 			m.Lock()
 

--- a/await_return.go
+++ b/await_return.go
@@ -9,7 +9,7 @@ import (
 // every item, collecting the return values of each execution into a new slice.
 // The returned slice has the same length and ordering as the input: result i
 // corresponds to input i.
-// If any error is encountered, the group's context is cancelled and execution
+// If any error is encountered, the group's context is canceled and execution
 // stops.
 // The returned slice should not be accessed until the group's Wait has
 // returned.
@@ -36,7 +36,7 @@ func SliceReturn[T, O any](g ctxErrgroup, vs []T, fn func(context.Context, T) (O
 // item. `fn` returns a (possibly new) key, a value, and an error; the returned
 // key/value pair is collected into a new output map. This lets you transform
 // both the keys and the values of a map concurrently.
-// If any error is encountered, the group's context is cancelled and execution
+// If any error is encountered, the group's context is canceled and execution
 // stops.
 // Writes back to the output map are guarded by a mutex because Go maps are not
 // safe for concurrent writes. If `fn` returns the same key for two different

--- a/ctxerrgroup.go
+++ b/ctxerrgroup.go
@@ -1,3 +1,12 @@
+// Package await provides small, generic helpers for fanning work out across
+// goroutines on top of golang.org/x/sync/errgroup. It adds three things on top
+// of a plain errgroup: Go-generics helpers for running a function over a single
+// value, a slice, or a map; helpers that collect or replace results without you
+// having to manage synchronization; and automatic recovery of panics in worker
+// goroutines (surfaced as a PanicError instead of crashing the process).
+//
+// All helpers share the group's context, so the first non-nil error (or panic)
+// cancels that context and Wait returns it.
 package await
 
 import (
@@ -7,8 +16,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// ctxErrgroup is a wrapper around errgroup. It manages passing in context
-// to avoid issues when not using the errgroup's returned context.
+// ctxErrgroup is a wrapper around errgroup.Group. It carries the context
+// returned by errgroup.WithContext alongside the group itself so callers do
+// not accidentally use a different (uncancelled) context inside their workers,
+// a common source of bugs when using errgroup directly.
 type ctxErrgroup struct {
 	ctx context.Context
 	g   *errgroup.Group
@@ -34,15 +45,19 @@ func Group(ctx context.Context, options ...Option) ctxErrgroup {
 	return ceg
 }
 
-// WithLimit sets the maximum amount of goroutines running in the errgroup at
-// any point in time.
+// WithLimit sets the maximum number of goroutines that may run concurrently in
+// the group at any point in time. A non-positive limit means no limit. See
+// errgroup.Group.SetLimit for the underlying semantics.
 func WithLimit(limit int) Option {
 	return func(ceg ctxErrgroup) {
 		ceg.g.SetLimit(limit)
 	}
 }
 
-// PanicError wraps a recovered panic and is returned if a goroutine panics.
+// PanicError wraps a value recovered from a panicking worker goroutine. When a
+// function passed to Go panics, await recovers it and returns it as a
+// PanicError from Wait rather than letting the panic crash the process. The
+// original recovered value is available via the Panic field.
 type PanicError struct {
 	Panic any
 }
@@ -54,9 +69,10 @@ func (pe PanicError) Error() string {
 	return fmt.Sprintf("goroutine panicked: %s", pe.Panic)
 }
 
-// Go adds a call to the errgroup, which passes the context provided to Group
-// into fn. Any error returned from the function provided will stop execution
-// for the entire group.
+// Go adds a call to the group, passing the group's context into fn. Any error
+// returned from fn cancels the group's context and stops execution for the
+// entire group. If fn panics, the panic is recovered and returned from Wait as
+// a PanicError so a single bad worker cannot take down the whole process.
 func (ceg ctxErrgroup) Go(fn func(ctx context.Context) error) {
 	ceg.g.Go(func() (err error) {
 		defer func() {


### PR DESCRIPTION
## Summary

- Adds a comprehensive `README.md` covering features, install, the Group vs. `*Context` ergonomics, error/cancellation and panic-recovery semantics, a full API reference, examples, and thread-safety notes.
- Fixes pervasive typos and several incorrect copy-pasted doc comments across the package (e.g. `SliceReturnContext` and `MapReturn` had wrong descriptions).
- Adds a package-level doc comment and documents the non-obvious concurrency and panic-recovery behavior.
- Removes now-redundant loop-variable shadowing (`v := v` / `k, v := k, v`). Loop variables have been per-iteration scoped since Go 1.22, and the module targets Go 1.25, so the shadowing was dead code — `copyloopvar` (enabled in `.golangci.yml`) would flag it.

No behavior changes. The MIT `LICENSE` already existed and is unchanged.

## Test plan

- `go build ./...` passes
- `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)